### PR TITLE
[DSI-7560] Upgrade to Node version 22 

### DIFF
--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -81,9 +81,9 @@ variables:
   - name: pr
     value: ${{ or(eq(parameters.pr, 'true'), contains(variables['Build.SourceBranch'],'release')) }}
   - name: northeurope
-    value: 'tran,pp,pr'
+    value: "tran,pp,pr"
   - name: westeurope
-    value: 'tran,dev,test,pp,pr'
+    value: "tran,dev,test,pp,pr"
 
 stages:
   # Code Scans & Build the artifact for deployment
@@ -112,68 +112,68 @@ stages:
                 - ${{ if eq(variables.pr, 'true') }}:
                     - pr
               pm2ProcessFileName: process.json
-              nodeVersionSpec: "18.17.0"
+              nodeVersionSpec: "22.11.0"
               useRevisedLinting: true
 
-  - ${{ each location in parameters.location }}:           
-    - ${{each env in split(variables[location],',') }}:
-      - ${{ if eq(variables[env], 'true') }}:
-        - stage: Deployment_${{env}}_${{location}}
-          displayName: "Deployment [${{env}}] ${{location}}"
-          ${{ if eq(location,'westeurope') }}:
-            dependsOn:
-              - scanBuildApp
-            condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
-          ${{ if eq(location,'northeurope') }}:
-            ${{ if eq(length(parameters.location), 2) }}:
-              dependsOn:
-                - scanBuildApp
-                - Deployment_${{env}}_westeurope
-              condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
-            ${{ else }}:
-              dependsOn:
-                - scanBuildApp
-              condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
-          variables:
-            - name: secRegionId
-              value: $(${{ format('{0}{1}', location, 'Id') }})
-            - name: environmentId
-              value: $[variables['${{env}}EnvId']]
-            - name: ServConName
-              value: ${{ format('{0}{1}', env, 'ServCon') }}
-            - name: ShaCodeName
-              value: ${{ format('{0}{1}', env, 'ShaCode') }}
-          jobs:
-            - template: pipeline/deployment.yml@devopsTemplates
-              parameters:
-                serviceConnection: $(${{variables.ServConName}})
-                # shaPool: $[variables['${{env}}ShaPool']]
-                # shaCode: $(${{variables.ShaCodeName}})
-                devOpsEnv: ${{variables.secRegionId}}${{env}}
-                environmentName: ${{env}}
-                applicationShortName: ${{variables.applicationShortName}}
-                applicationFullName: ${{variables.applicationFullName}}
-                releaseArtifactName: ${{variables.applicationShortName}}-${{env}}-$(Build.BuildId)-release
-                InfrDeploy: ${{parameters.InfrDeploy}}
-                deploymentLocation: ${{location}}
-                runtimeStack: NODE|18-lts
-                pm2ProcessFileName: process.json
-                gitCheck: ${{parameters.gitCheck}}
+  - ${{ each location in parameters.location }}:
+      - ${{each env in split(variables[location],',') }}:
+          - ${{ if eq(variables[env], 'true') }}:
+              - stage: Deployment_${{env}}_${{location}}
+                displayName: "Deployment [${{env}}] ${{location}}"
+                ${{ if eq(location,'westeurope') }}:
+                  dependsOn:
+                    - scanBuildApp
+                  condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
+                ${{ if eq(location,'northeurope') }}:
+                  ${{ if eq(length(parameters.location), 2) }}:
+                    dependsOn:
+                      - scanBuildApp
+                      - Deployment_${{env}}_westeurope
+                    condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
+                  ${{ else }}:
+                    dependsOn:
+                      - scanBuildApp
+                    condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
+                variables:
+                  - name: secRegionId
+                    value: $(${{ format('{0}{1}', location, 'Id') }})
+                  - name: environmentId
+                    value: $[variables['${{env}}EnvId']]
+                  - name: ServConName
+                    value: ${{ format('{0}{1}', env, 'ServCon') }}
+                  - name: ShaCodeName
+                    value: ${{ format('{0}{1}', env, 'ShaCode') }}
+                jobs:
+                  - template: pipeline/deployment.yml@devopsTemplates
+                    parameters:
+                      serviceConnection: $(${{variables.ServConName}})
+                      # shaPool: $[variables['${{env}}ShaPool']]
+                      # shaCode: $(${{variables.ShaCodeName}})
+                      devOpsEnv: ${{variables.secRegionId}}${{env}}
+                      environmentName: ${{env}}
+                      applicationShortName: ${{variables.applicationShortName}}
+                      applicationFullName: ${{variables.applicationFullName}}
+                      releaseArtifactName: ${{variables.applicationShortName}}-${{env}}-$(Build.BuildId)-release
+                      InfrDeploy: ${{parameters.InfrDeploy}}
+                      deploymentLocation: ${{location}}
+                      runtimeStack: NODE|22-lts
+                      pm2ProcessFileName: process.json
+                      gitCheck: ${{parameters.gitCheck}}
 
-        - ${{ if and(eq(env, 'pp'),eq(location, 'westeurope')) }}:
-            - stage: releasebranch
-              displayName: "GitHub Release Branch Creation"
-              dependsOn:
-                - Deployment_${{env}}_${{location}}
-              jobs:
-                - template: pipeline/releaseCreation.yml@devopsTemplates
+              - ${{ if and(eq(env, 'pp'),eq(location, 'westeurope')) }}:
+                  - stage: releasebranch
+                    displayName: "GitHub Release Branch Creation"
+                    dependsOn:
+                      - Deployment_${{env}}_${{location}}
+                    jobs:
+                      - template: pipeline/releaseCreation.yml@devopsTemplates
 
-        - ${{ if and(eq(env, 'pr'),eq(location, 'westeurope')) }}:
-            - stage: branchPrTag
-              displayName: "GitHub PR & Release Branch Tag"
-              dependsOn:
-                - Deployment_${{env}}_${{location}}
-              jobs:
-                - template: pipeline/tagCreation.yml@devopsTemplates
-                  parameters:
-                    applicationName: ${{variables.applicationFullName}}
+              - ${{ if and(eq(env, 'pr'),eq(location, 'westeurope')) }}:
+                  - stage: branchPrTag
+                    displayName: "GitHub PR & Release Branch Tag"
+                    dependsOn:
+                      - Deployment_${{env}}_${{location}}
+                    jobs:
+                      - template: pipeline/tagCreation.yml@devopsTemplates
+                        parameters:
+                          applicationName: ${{variables.applicationFullName}}

--- a/DevOps/templates/template.json
+++ b/DevOps/templates/template.json
@@ -38,7 +38,7 @@
     },
     "nodeVersion": {
       "type": "string",
-      "defaultValue": "10.16.0",
+      "defaultValue": "22.11.0",
       "metadata": {
         "description": "The default NodeJS version that the App Service will run"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,18 +23,18 @@
         "winston": "^3.17.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.16.0",
-        "eslint": "^9.16.0",
+        "@eslint/js": "^9.21.0",
+        "eslint": "^9.21.0",
         "eslint-formatter-junit": "^8.40.0",
-        "eslint-plugin-jest": "^28.9.0",
-        "globals": "^15.13.0",
+        "eslint-plugin-jest": "^28.11.0",
+        "globals": "^15.15.0",
         "husky": "^9.1.7",
-        "jest": "^29.6.3",
-        "jest-cli": "^29.6.3",
+        "jest": "^29.7.0",
+        "jest-cli": "^29.7.0",
         "jest-junit": "^16.0.0",
-        "lint-staged": "^15.2.10",
-        "node-mocks-http": "^1.11.0",
-        "prettier": "^3.4.2"
+        "lint-staged": "^15.4.3",
+        "node-mocks-http": "^1.16.2",
+        "prettier": "^3.5.3"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
         "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.6",
         "login.dfe.dao": "^5.0.3",
-        "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
+        "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.2",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
         "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
@@ -6519,8 +6519,8 @@
       }
     },
     "node_modules/login.dfe.express-error-handling": {
-      "version": "3.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.express-error-handling.git#2b1de1f9e1cc8d14afff441ff97c344d9c6cbc86",
+      "version": "3.0.2",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.express-error-handling.git#405082e18f5e9eff0d2b4279626d6e5e3abb52a6",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "applicationinsights": "^2.0.0",
-        "express": "^4.18.1",
+        "applicationinsights": "^2.9.6",
+        "express": "^4.21.2",
         "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
         "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.6",
         "login.dfe.dao": "^5.0.3",
@@ -18,9 +18,9 @@
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
         "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
-        "nodemon": "^3.1.4",
-        "simpl-schema": "^3.4.1",
-        "winston": "^3.8.2"
+        "nodemon": "^3.1.9",
+        "simpl-schema": "^3.4.6",
+        "winston": "^3.17.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.16.0",
@@ -39,6 +39,8 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha1-7UQbb6YAByUgzhi0PSyMyMrsx/Q=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -51,6 +53,8 @@
     },
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -61,6 +65,8 @@
     },
     "node_modules/@azure/core-auth": {
       "version": "1.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.7.2.tgz",
+      "integrity": "sha1-VYt8t90SsAvuwHrl31kH103x69k=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -73,6 +79,8 @@
     },
     "node_modules/@azure/core-client": {
       "version": "1.9.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz",
+      "integrity": "sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -87,24 +95,48 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-client/node_modules/@azure/core-util": {
-      "version": "1.9.2",
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-http-compat/-/core-http-compat-2.2.0.tgz",
+      "integrity": "sha1-IP9TWyRgFR6n5odnKHmWyEzShzg=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat/node_modules/@azure/core-auth": {
+      "version": "1.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.9.0.tgz",
+      "integrity": "sha1-rHJbA/q+PIkjcQZe6eIEG+4P0aw=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-http-compat": {
-      "version": "2.1.2",
+    "node_modules/@azure/core-http-compat/node_modules/@azure/core-rest-pipeline": {
+      "version": "1.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.0.tgz",
+      "integrity": "sha1-TMYNPy7mjPDvN5hRtO0XX3kyyMU=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
-        "@azure/core-client": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.3.0"
+        "@azure/core-auth": "^1.8.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -112,6 +144,8 @@
     },
     "node_modules/@azure/core-lro": {
       "version": "2.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha1-eHEFAnog5Fx3ZRqYsBpNOwG3Wgg=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -125,6 +159,8 @@
     },
     "node_modules/@azure/core-paging": {
       "version": "1.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha1-QNOGDcLffykdZjULLP2RcVJkM+c=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -134,36 +170,28 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.10.1",
+      "version": "1.16.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
+      "integrity": "sha1-veO8PrrX+IXd2d5q9eWo/CVLKH4=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.9.0",
         "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.1.2",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
+      "integrity": "sha1-e+XVPDUi1jnPGQQsvNsZ9xvDWrI=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -173,61 +201,9 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/identity": {
-      "version": "4.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.9.2",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.3.0",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.14.0",
-        "@azure/msal-node": "^2.9.2",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/@azure/core-util": {
-      "version": "1.9.2",
+      "version": "1.11.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.11.0.tgz",
+      "integrity": "sha1-9TD8Z+c4rqhy+90cyEFucCGfrac=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -237,18 +213,91 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/identity/node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
+    "node_modules/@azure/identity": {
+      "version": "4.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-4.7.0.tgz",
+      "integrity": "sha1-s7xXrsQEMomRCP1BF36BaOe7YiM=",
       "license": "MIT",
       "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^4.2.0",
+        "@azure/msal-node": "^3.2.1",
+        "events": "^3.0.0",
+        "jws": "^4.0.0",
+        "open": "^10.1.0",
+        "stoppable": "^1.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/core-auth": {
+      "version": "1.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.9.0.tgz",
+      "integrity": "sha1-rHJbA/q+PIkjcQZe6eIEG+4P0aw=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@azure/identity/node_modules/@azure/core-rest-pipeline": {
+      "version": "1.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.0.tgz",
+      "integrity": "sha1-TMYNPy7mjPDvN5hRtO0XX3kyyMU=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.8.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-common": {
+      "version": "15.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-15.2.0.tgz",
+      "integrity": "sha1-9OOLqFwKMiCLcEbgEcIf9ie2dVw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-node": {
+      "version": "3.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-3.2.3.tgz",
+      "integrity": "sha1-x0LWbTqRg8HfpBYGMtiJHGmve8w=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "15.2.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@azure/identity/node_modules/jwa": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
@@ -258,17 +307,40 @@
     },
     "node_modules/@azure/identity/node_modules/jws": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/@azure/keyvault-keys": {
-      "version": "4.8.0",
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-common/-/keyvault-common-2.0.0.tgz",
+      "integrity": "sha1-keUN8B2b+o9V8Qe7nNvFdYaysqQ=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.5.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-keys": {
+      "version": "4.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-keys/-/keyvault-keys-4.9.0.tgz",
+      "integrity": "sha1-g60jcEKdH1dubFxZ/xZXYeLY/qs=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.5.0",
         "@azure/core-http-compat": "^2.0.1",
@@ -277,6 +349,7 @@
         "@azure/core-rest-pipeline": "^1.8.1",
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.0.0",
+        "@azure/keyvault-common": "^2.0.0",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.2.0"
       },
@@ -284,18 +357,10 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/keyvault-keys/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@azure/logger": {
       "version": "1.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/logger/-/logger-1.1.4.tgz",
+      "integrity": "sha1-Ijy/K0JN+mZHjOmk9XX1nG83l2g=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -305,27 +370,42 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.20.0",
+      "version": "4.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-4.5.0.tgz",
+      "integrity": "sha1-+9xPWPDzelSHGZ9HBuX4oEzQAjQ=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.14.0"
+        "@azure/msal-common": "15.2.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "15.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-15.2.0.tgz",
+      "integrity": "sha1-9OOLqFwKMiCLcEbgEcIf9ie2dVw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@azure/msal-common": {
-      "version": "14.14.0",
+      "version": "14.16.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.16.0.tgz",
+      "integrity": "sha1-80cPyux4jb5QhZlSzUmTQL2iPXo=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.12.0",
+      "version": "2.16.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.16.2.tgz",
+      "integrity": "sha1-Prdo02iD6m+ak5wLW0Z7UY54//w=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.14.0",
+        "@azure/msal-common": "14.16.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -334,26 +414,31 @@
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.8.tgz",
+      "integrity": "sha1-erxrBWNUQU5rrMNmhzxn+MvnGKo=",
       "license": "MIT",
       "dependencies": {
-        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-tracing": "^1.2.0",
         "@azure/logger": "^1.0.0",
-        "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.15.2",
-        "@opentelemetry/instrumentation": "^0.41.2",
-        "tslib": "^2.2.0"
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
+      "version": "7.26.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha1-S1+rl9MzOO/5FiNQVfDrwh5XOoU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -361,7 +446,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.2",
+      "version": "7.26.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha1-ghwdNWQcNVKE1KhwuKSnsMFB42c=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -369,20 +456,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.2",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/core/-/core-7.26.9.tgz",
+      "integrity": "sha1-cYOFQqSx5J3+01PXrLxuuJ9KdvI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/helper-compilation-targets": "^7.25.2",
-        "@babel/helper-module-transforms": "^7.25.2",
-        "@babel/helpers": "^7.25.0",
-        "@babel/parser": "^7.25.0",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.2",
-        "@babel/types": "^7.25.2",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.9",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -397,29 +486,10 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.3.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -427,27 +497,32 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.26.9.tgz",
+      "integrity": "sha1-dalIKtPQzHGIpTeqSRC8Wdtny8o=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.2",
+      "version": "7.26.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha1-ddkruNjVEwHA1J5Splyaf+lFFNg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.2",
-        "@babel/helper-validator-option": "^7.24.8",
-        "browserslist": "^4.23.1",
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -457,6 +532,8 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -464,26 +541,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.7",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha1-5/jSBgLr2/nrvqCgdR+w8qQUFxU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.2",
+      "version": "7.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha1-jOVOydWSaV5Y2EzYhLe1xqL97q4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "@babel/traverse": "^7.25.2"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -493,27 +573,19 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
+      "version": "7.26.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha1-GFgNAMmTQRetcZOSxPZYXJMzzDU=",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.24.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha1-Gqu3Lucu01eJtLvK08ooYs5hTow=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -521,7 +593,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha1-JLZOLD7HzTs8VHcpuNFocfIsvcc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -529,7 +603,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.8",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha1-huRb2KSat+A/J2V3+WF5ZT1B2nI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -537,101 +613,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.26.9.tgz",
+      "integrity": "sha1-KPP7RSUvyI7y3FR8ipEcJV/J/vY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.3",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.26.9.tgz",
+      "integrity": "sha1-2eeL7m3ID579jyNJ3Pu82s4oD9U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.26.9"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -642,6 +644,8 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -653,6 +657,8 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha1-TJpvZp9dDN8bkKFnHpoUa+UwDOo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -664,6 +670,8 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -673,8 +681,42 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha1-GV34mxRrS3izv4l/16JXyEZZ1AY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha1-OxQShHaZ7qc5tPJgLHTONvawsPc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -686,6 +728,8 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -696,11 +740,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.7",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha1-o0MToXjqVvGVFZm5KcHOrO5xkpA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -711,6 +757,8 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -722,6 +770,8 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -733,6 +783,8 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -744,6 +796,8 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -755,6 +809,8 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -766,6 +822,8 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -775,8 +833,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha1-DcZnHsDqIrbpShEU+FeXDNOd4a0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha1-wc/a3DWmRiQAAfBhOCR7dBw02Uw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -790,11 +866,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.7",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+      "integrity": "sha1-Z92it02kNyfPIdRs+a/vI/Q2U5k=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -804,28 +882,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha1-RXetPd9D0ZRSjP9OH6ayMvpgm7I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.3",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.26.9.tgz",
+      "integrity": "sha1-Q5jyOUumbQXZiLKtE8IZoshXRho=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.2",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -833,43 +915,25 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.3.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@babel/traverse/node_modules/globals": {
       "version": "11.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/@babel/traverse/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.26.9.tgz",
+      "integrity": "sha1-CLQ97HnujmgsKsYxwBC9ysVKIc4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -877,11 +941,15 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha1-7GzSN0QHALwjyiMIf1E8dVCJWLA=",
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
@@ -889,6 +957,8 @@
     },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha1-f36X7ppyXf/HgI2TZozJhOHcR3o=",
       "license": "MIT",
       "dependencies": {
         "colorspace": "1.1.x",
@@ -897,30 +967,51 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
+      "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha1-0RRb8sIBMtZABJXW30v1k2L9nVY=",
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha1-z8bP/jnfOQo4Qc3iq8z5Lqp64OA=",
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.1",
+      "version": "0.19.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha1-MGC4CeERq/yXrbC7EXJ3i5DLRqo=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.5",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -928,27 +1019,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/debug": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
-    },
     "node_modules/@eslint/core": {
-      "version": "0.9.1",
+      "version": "0.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha1-X5YMPVdyi+n2xlvYSqaqYTB4eY4=",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -958,7 +1032,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
+      "version": "3.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha1-lqVY9FhCmJzKfqHs14WtVJEZOEY=",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -978,23 +1054,10 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/debug": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha1-iY10E8Kbq89rr+Vvyt3thYrack4=",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1003,28 +1066,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
-    },
     "node_modules/@eslint/js": {
-      "version": "9.16.0",
+      "version": "9.21.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha1-QwPvTgcibYfDlbj61SeHY+nBXAg=",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.5",
+      "version": "2.1.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha1-WDaatbWzyhF4gMD2wLDzL2lQ8k8=",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.4",
+      "version": "0.2.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha1-mQHVLBNvuPN1kGpz3MOCZGw7aic=",
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1033,6 +1099,8 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha1-F8Vcp9Qmcz/jxWGQa4Fzwza0Cnc=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -1040,6 +1108,8 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha1-7ioQ6qvRExmHvwSI/ZuCAXTNdl4=",
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -1051,6 +1121,8 @@
     },
     "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
       "version": "0.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha1-xypcdqn7rzSI4jGxPcUsDae6tCo=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -1062,6 +1134,8 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha1-+5B2JN8yVtBLmqLfUNeql+xkh0g=",
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
@@ -1072,27 +1146,10 @@
         "node": ">=10.10.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array/node_modules/debug": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
-    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -1104,10 +1161,14 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha1-Siho111taWPkI7z5C3/RvjQ0CdM=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
+      "version": "0.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha1-GGBHPeffoVRnZ0SPMz24DLD/IWE=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -1119,10 +1180,14 @@
     },
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha1-bWGzCXRwrx/bvmInlbiSHUIBjhE=",
       "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1138,6 +1203,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
       "version": "1.0.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1146,6 +1213,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1158,6 +1227,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
       "version": "3.14.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1170,6 +1241,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1181,6 +1254,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1195,6 +1270,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1206,6 +1283,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1214,11 +1293,15 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
       "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1227,6 +1310,8 @@
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha1-zUgi29uEUpJlxaK9tSmjycyVD/w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1243,6 +1328,8 @@
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha1-tszMI58w/zZglljFpeIpF1fORI8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1289,6 +1376,8 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha1-JNYfVP8feG881Ac7S5RBY4O68qc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1303,6 +1392,8 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha1-dqPtsMt1O3Dfv+Iyg1ENPUVDK/I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1315,6 +1406,8 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha1-Aj7+XSaopw8hZ30KGvwPCkTjocY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1326,6 +1419,8 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha1-/ZG/H/+xbX0NJKQmqxpHpJiBpWU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1342,6 +1437,8 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha1-jZKQ+exH/3cmB/qGTKHVou+uHU0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1356,6 +1453,8 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha1-BLJi7LO4+qg7Cz0yFiOXI5Po9Mc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1398,6 +1497,8 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha1-Qwtc6KTgBEp+OBlmMwWnswkcjgM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1409,6 +1510,8 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha1-2Quncglc83o0peuUE/G1YqCFVMQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1422,6 +1525,8 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha1-jbmoCqGgl7siYlcmhnNLrtmxZXw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1436,6 +1541,8 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha1-bO+XfOHTmDSjrqiHoXJmKKbwcs4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1450,6 +1557,8 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha1-3y3Zw0bH13aLigZjmZRkDGQuKEw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1475,6 +1584,8 @@
     },
     "node_modules/@jest/types": {
       "version": "29.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha1-ETH4z2NOfoTF53urEvBSr1hfulk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1490,7 +1601,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
+      "version": "0.3.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha1-Tw4GNi4BNi+CPTSPGHKwj2ZtgUI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1504,6 +1617,8 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1512,6 +1627,8 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha1-VY+2Ry7RakyFC4iVMOazZDjEkoA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1520,11 +1637,15 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha1-MYi8snOkFLDSFf0ipYVAuYm5QJo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha1-FfGQ6YiV8/wjJ27hS8drZ1wuUPA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1533,11 +1654,15 @@
       }
     },
     "node_modules/@js-joda/core": {
-      "version": "5.6.3",
+      "version": "5.6.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.4.tgz",
+      "integrity": "sha1-q6/OmzAwJjm/5KcbrVEg/jllTxA=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
+      "integrity": "sha1-a7eIspAuSL9dRgw4xrt/7daG3dc=",
       "license": "MIT"
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -1547,6 +1672,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1559,6 +1685,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1571,6 +1698,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1583,6 +1711,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1595,6 +1724,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1607,6 +1737,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1614,6 +1745,8 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1625,6 +1758,8 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1632,6 +1767,8 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1643,16 +1780,32 @@
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha1-0D66aCc9wPdQnio9XLoh6uEDef4=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/core": {
-      "version": "1.25.1",
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha1-1AAbmqNYA2e0D+iJ81QAFPdmzIc=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha1-oLRouzljWN+AGIFwnqOCmfwwqyc=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -1661,14 +1814,26 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha1-M3+yvKBFPQcmaW50X1AGRBH2RtY=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.41.2",
+      "version": "0.57.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha1-iSRUnXlBuhtcbwTVUpz0gzBFbR0=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.4.2",
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.1",
+        "semver": "^7.5.2",
         "shimmer": "^1.2.1"
       },
       "engines": {
@@ -1679,26 +1844,39 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.25.1",
+      "version": "1.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha1-pOrhfr2WlH/cemT5McpLceGM6WQ=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha1-M3+yvKBFPQcmaW50X1AGRBH2RtY=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.25.1",
+      "version": "1.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha1-QaQiNAltyY6PRU0kVR/IC4Fv6zQ=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -1707,8 +1885,19 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha1-M3+yvKBFPQcmaW50X1AGRBH2RtY=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.25.1",
+      "version": "1.30.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
+      "integrity": "sha1-OkLExHVILy7IfBKq2Ygy3ACH3Jo=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -1716,11 +1905,15 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha1-Zmf6wWxDa1Q0o4ejTe2wExmPbm4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha1-ECk1fkTKkBphVYX20nc428iQhM0=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1729,21 +1922,18 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha1-Vf3/Hsq581QBkSna9N8N1Nkj6mY=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha1-PfFfJ7qFMZyqB7oI0HIYibs5wBc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1756,6 +1946,8 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.6.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha1-+DbGH0ixNG59Kw2TxtrMW5U106s=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1764,6 +1956,8 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha1-VnJRNwHBshmbxtrWNqnXSRWGdm8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1773,31 +1967,18 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.20.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+      "integrity": "sha1-jcnwrg8gLAjY1Nq2SJEsjWA44/c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha1-oVXyFpCHGVNBDfS2tvUxh/BQCRc=",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -1805,50 +1986,31 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha1-Yo7/7q4gZKG055946B2Ht+X8e1A=",
       "license": "MIT"
-    },
-    "node_modules/@types/express": {
-      "version": "4.17.21",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha1-Kga8D2iiCrN7PjaqI4vmq99J6LQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha1-dznCMqH+6bTTzomF8xTAxtM1Sdc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha1-UwR2FK5y4Z/AQB2HLeOuK0zjUL8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1857,6 +2019,8 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha1-DwPj0vZw+9rFhuNLQzeDBwzBb1Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1865,36 +2029,29 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "license": "MIT"
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "dev": true,
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "license": "MIT"
     },
     "node_modules/@types/ms": {
-      "version": "0.7.34",
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha1-BSqmekjszEMJ1/AZG35BQ0uQu3g=",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.1.0",
+      "version": "22.13.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-22.13.9.tgz",
+      "integrity": "sha1-XZqPepdaW9PvJnNS3rlvsT7ALso=",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.15",
+      "version": "4.0.18",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/readable-stream/-/readable-stream-4.0.18.tgz",
+      "integrity": "sha1-XY0V0mx3ZQDOVzyuWAeH0UmCO/w=",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1903,46 +2060,39 @@
     },
     "node_modules/@types/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
     },
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha1-m3Bq+W+gZBaCiEI5enDfu/HBTe0=",
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha1-YgkyHrLBcSp+dGZCK4yx/A2d1dg=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha1-dP75/7qhmOuLWIvgKfOLACmcqiw=",
       "license": "MIT"
     },
     "node_modules/@types/validator": {
-      "version": "13.12.0",
+      "version": "13.12.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.12.2.tgz",
+      "integrity": "sha1-dgMp51bhikqrgvxQK1Hr3+u+SfU=",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.32",
+      "version": "17.0.33",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha1-jDIwPag+7AUKhLPHrnufki0T4y0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1951,16 +2101,20 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha1-gV4wt4bS6PDc2F/VvPXhoE0AjxU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.18.0",
+      "version": "8.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
+      "integrity": "sha1-sGYj+tVKOnf62rX2Uu917TeAtUU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0"
+        "@typescript-eslint/types": "8.26.0",
+        "@typescript-eslint/visitor-keys": "8.26.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1971,7 +2125,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.18.0",
+      "version": "8.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/types/-/types-8.26.0.tgz",
+      "integrity": "sha1-xOk6j686OKjYrbAH3Hg08cie578=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1983,18 +2139,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.18.0",
+      "version": "8.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
+      "integrity": "sha1-EolyFyAFpzduNO0uy6Tik2OwytE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/types": "8.26.0",
+        "@typescript-eslint/visitor-keys": "8.26.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2004,35 +2162,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2045,20 +2191,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.18.0",
+      "version": "8.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/utils/-/utils-8.26.0.tgz",
+      "integrity": "sha1-hF0g7YN4pVlOZEX1TlO5cq7ns+Y=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/typescript-estree": "8.18.0"
+        "@typescript-eslint/scope-manager": "8.26.0",
+        "@typescript-eslint/types": "8.26.0",
+        "@typescript-eslint/typescript-estree": "8.26.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2069,15 +2212,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.18.0",
+      "version": "8.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
+      "integrity": "sha1-pIdiFnVsaRMOqVjfO3ciLCrZUpA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/types": "8.26.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -2088,23 +2233,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.1",
+      "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha1-0Gu7OE689sUF/eHD0O1N3/4Kr/g=",
       "license": "ISC"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -2115,6 +2253,8 @@
     },
     "node_modules/accepts": {
       "version": "1.3.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha1-C/C+EltnAUrcsLCSHmLbe//hay4=",
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -2126,6 +2266,8 @@
     },
     "node_modules/acorn": {
       "version": "8.14.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha1-Bj4scMrF+09kZ/CxEVLgTGgnlbA=",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2134,8 +2276,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha1-frFVexugXvGLXtDsZ1kb+rBGiO8=",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
@@ -2143,42 +2287,26 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
+      "version": "7.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha1-KUNeuCG8QZRjOluJ5bxHA7r8JaE=",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2193,6 +2321,8 @@
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2205,19 +2335,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2225,6 +2346,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2238,6 +2361,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2248,12 +2373,13 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.9.5",
+      "version": "2.9.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/applicationinsights/-/applicationinsights-2.9.6.tgz",
+      "integrity": "sha1-Z1KOZn15U8jdV7X7FuCkcU/Aeu0=",
       "license": "MIT",
       "dependencies": {
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-rest-pipeline": "1.10.1",
-        "@azure/core-util": "1.2.0",
+        "@azure/core-auth": "1.7.2",
+        "@azure/core-rest-pipeline": "1.16.3",
         "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-web-snippet": "1.0.1",
         "@opentelemetry/api": "^1.7.0",
@@ -2279,25 +2405,35 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "license": "MIT"
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
     },
     "node_modules/async": {
-      "version": "3.2.5",
+      "version": "3.2.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-3.2.6.tgz",
+      "integrity": "sha1-Gwco4Ukp1RuFtEm38G4nwRReOM4=",
       "license": "MIT"
     },
     "node_modules/async-hook-jl": {
       "version": "1.7.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha1-T9JcL4ZNuvJ5xhDXO/l7GyhZXmg=",
       "license": "MIT",
       "dependencies": {
         "stack-chain": "^1.3.7"
@@ -2308,6 +2444,8 @@
     },
     "node_modules/async-listener": {
       "version": "0.6.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha1-p8l6vlcLpgLXgic8DeYKUePhfLw=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "semver": "^5.3.0",
@@ -2319,17 +2457,17 @@
     },
     "node_modules/async-listener/node_modules/semver": {
       "version": "5.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha1-9DaZGSJbaExWCFmYrGPb0FvgINU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2350,6 +2488,8 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha1-+ojsWSMv2bTjbbvFQKjsmptH2nM=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2365,6 +2505,8 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha1-0QyIhcISVXThwjHKyt+VVnXhzj0=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2380,6 +2522,8 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2388,6 +2532,8 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha1-qtvpQ0ZBgqiSLDySfDBn/0DSRiY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2401,22 +2547,27 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.0.1",
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+      "integrity": "sha1-mpKer+zkGWEu9K5PYLGGLrrY7zA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -2424,6 +2575,8 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha1-+gX6UQ59STiW17DdIDNgHIQPFxw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2439,10 +2592,14 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
       "funding": [
         {
           "type": "github",
@@ -2461,6 +2618,8 @@
     },
     "node_modules/base64url": {
       "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha1-Y5nVcuK8P5CpqLItXbsKMtM/eI0=",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2468,6 +2627,8 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha1-9uFKl4WNMnJSIAJC1Mz+UixEVSI=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2477,7 +2638,9 @@
       }
     },
     "node_modules/bl": {
-      "version": "6.0.14",
+      "version": "6.0.20",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.20.tgz",
+      "integrity": "sha1-cFJ6/CfSFYuI21WpmtiBOrfYKRQ=",
       "license": "MIT",
       "dependencies": {
         "@types/readable-stream": "^4.0.0",
@@ -2488,10 +2651,14 @@
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha1-GVNDEiHG+1zWPEs21T+rCSjlSMY=",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -2512,8 +2679,25 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2522,6 +2706,8 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2531,7 +2717,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
+      "version": "4.24.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha1-xrKGWj8IvLhgoOgnOJADuf5obks=",
       "dev": true,
       "funding": [
         {
@@ -2549,10 +2737,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2563,6 +2751,8 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2571,6 +2761,8 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
       "funding": [
         {
           "type": "github",
@@ -2593,17 +2785,22 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/bullmq": {
-      "version": "5.35.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bullmq/-/bullmq-5.35.1.tgz",
-      "integrity": "sha1-XJoLmUff9bGpsjmbcrIeSKtD51o=",
+      "version": "5.41.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bullmq/-/bullmq-5.41.7.tgz",
+      "integrity": "sha1-UWErT9hIRLZ2ovYqqjI3rZQt3aI=",
+      "license": "MIT",
       "dependencies": {
         "cron-parser": "^4.9.0",
         "ioredis": "^5.4.1",
@@ -2622,12 +2819,30 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk=",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bunyan": {
       "version": "1.8.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha1-jONMqQihfQd2V2yhsvbL2RbpO0Y=",
       "engines": [
         "node >=0.10.0"
       ],
@@ -2644,6 +2859,8 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha1-iwvuuYYFrfGxKPpDhkA8AJ4CIaU=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2651,6 +2868,8 @@
     },
     "node_modules/cache-manager": {
       "version": "3.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cache-manager/-/cache-manager-3.6.3.tgz",
+      "integrity": "sha1-SAUvPPnuS6wcu2re7dafr52k7AQ=",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.3",
@@ -2660,10 +2879,14 @@
     },
     "node_modules/cache-manager/node_modules/async": {
       "version": "3.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-3.2.3.tgz",
+      "integrity": "sha1-rFPa/T9HIO6eihYGKPGOqR3xlsk=",
       "license": "MIT"
     },
     "node_modules/cache-manager/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -2674,17 +2897,31 @@
     },
     "node_modules/cache-manager/node_modules/yallist": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "license": "ISC"
     },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
       "license": "MIT",
       "dependencies": {
-        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2695,6 +2932,8 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2702,6 +2941,8 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2709,7 +2950,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001649",
+      "version": "1.0.30001702",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
+      "integrity": "sha1-zeFvqK2qBmwErsKWe2zeRjVGRMQ=",
       "dev": true,
       "funding": [
         {
@@ -2729,6 +2972,8 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2743,6 +2988,8 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2751,6 +2998,8 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha1-GXxsxmnvKo3F57TZfuTgksPrDVs=",
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2773,6 +3022,8 @@
     },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2783,6 +3034,8 @@
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha1-QnmmICinsfJi80c/yWBfXiGMWbQ=",
       "dev": true,
       "funding": [
         {
@@ -2796,11 +3049,15 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.3.1",
+      "version": "1.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha1-D3lzHrjP4exyrNQGbvrJ1hmRsA0=",
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha1-JKSDHs9aawHd6zL7caSyCIsNzjg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2815,6 +3072,8 @@
     },
     "node_modules/cli-truncate": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha1-bMKKKST+6eJc6R6XPbVscGbmFyo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2828,54 +3087,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2887,8 +3102,60 @@
         "node": ">=12"
       }
     },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -2896,6 +3163,8 @@
     },
     "node_modules/cls-hooked": {
       "version": "4.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha1-rS6aQJJoDNr/6y01UdoOIl6uGQg=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "async-hook-jl": "^1.7.6",
@@ -2908,6 +3177,8 @@
     },
     "node_modules/cls-hooked/node_modules/semver": {
       "version": "5.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -2915,6 +3186,8 @@
     },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha1-iN2qRpBuMDtd4w0xU7fZ/goMGaw=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
@@ -2922,6 +3195,8 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2931,11 +3206,15 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha1-wLKbzTO80HeaE0TCE2BR5q/T2ek=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/color": {
       "version": "3.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color/-/color-3.2.1.tgz",
+      "integrity": "sha1-NUTcGYyvRJDD7MmnkLVP6f9F4WQ=",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.3",
@@ -2944,6 +3223,8 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2954,10 +3235,14 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "license": "MIT"
     },
     "node_modules/color-string": {
       "version": "1.9.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha1-RGf5FG8Db4Vbdk37W/hYK/NCx6Q=",
       "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
@@ -2966,6 +3251,8 @@
     },
     "node_modules/color/node_modules/color-convert": {
       "version": "1.9.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -2973,33 +3260,31 @@
     },
     "node_modules/color/node_modules/color-name": {
       "version": "1.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha1-nreT5oMwZ/cjWQL807CZF6AAqVo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/colorspace": {
       "version": "1.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha1-jUQtEYYVL2BFO/gHDNZus2TlkkM=",
       "license": "MIT",
       "dependencies": {
         "color": "^3.1.3",
         "text-hex": "1.0.x"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
-      "version": "12.1.0",
+      "version": "13.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha1-d2Fn22jHjzjczh+bjXuLmkiKv0Y=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3008,10 +3293,14 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha1-i4K076yCUSoCuwsdzsnSxejrW/4=",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -3022,6 +3311,8 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha1-i3cxYmVtHRCGeEyPI6VM5tc9eRg=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3029,6 +3320,8 @@
     },
     "node_modules/continuation-local-storage": {
       "version": "3.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "async-listener": "^0.6.0",
@@ -3037,11 +3330,15 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha1-L3PEIULV1c9xMQp0/ErmFnDl28k=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3049,14 +3346,20 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "license": "MIT"
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha1-o1XFs8seGvAroXf+ev1/7uSaUyA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3079,6 +3382,7 @@
       "version": "4.9.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cron-parser/-/cron-parser-4.9.0.tgz",
       "integrity": "sha1-A0BpSvPkagiUl4xvUqbbtcDxGtU=",
+      "license": "MIT",
       "dependencies": {
         "luxon": "^3.2.1"
       },
@@ -3088,6 +3392,8 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3099,14 +3405,26 @@
       }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/dedent": {
       "version": "1.5.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dedent/-/dedent-1.5.3.tgz",
+      "integrity": "sha1-ma7hnrm65VpnMncXtuhI0L93flo=",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3120,47 +3438,64 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha1-RLXyFHzTsA1LVhN2hZZvJv0l3Uo=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha1-e3umEgT/PkJbVWhprm0+nZ8XEs8=",
       "license": "MIT",
       "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha1-odmL+WDBUILYo/pp6DFQzMzDryY=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/denque": {
       "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha1-6T4aZWn7XmbxajwqKWRhfTSdarE=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
@@ -3168,6 +3503,8 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3175,6 +3512,8 @@
     },
     "node_modules/destroy": {
       "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha1-SANzVQmti+VSk0xn32FPlOZvoBU=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -3185,6 +3524,7 @@
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA=",
+      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=8"
@@ -3192,6 +3532,8 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3200,6 +3542,8 @@
     },
     "node_modules/diagnostic-channel": {
       "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
+      "integrity": "sha1-RLYJct6e4FXBYhZTWw6ds/ag79A=",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -3207,6 +3551,8 @@
     },
     "node_modules/diagnostic-channel-publishers": {
       "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.8.tgz",
+      "integrity": "sha1-cAVXqQLEQ8sR+Znxn1CouzvkkKA=",
       "license": "MIT",
       "peerDependencies": {
         "diagnostic-channel": "*"
@@ -3214,6 +3560,8 @@
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha1-Ter4lNEUB8Ue/IQYAS+ecLhOqSE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3222,6 +3570,8 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -3232,10 +3582,14 @@
     },
     "node_modules/dottie": {
       "version": "2.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dottie/-/dottie-2.0.6.tgz",
+      "integrity": "sha1-NFZOv8bsXldyJy1GZCStW2lkhNQ=",
       "license": "MIT"
     },
     "node_modules/dtrace-provider": {
       "version": "0.8.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha1-KZbVSQw34TR74mO0I+17KX+w2X4=",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "optional": true,
@@ -3246,8 +3600,24 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -3255,10 +3625,14 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha1-aauDWLFOiW+AzDnmIIe4hQDDrDs=",
       "license": "Apache-2.0",
       "dependencies": {
         "jake": "^10.8.5"
@@ -3271,12 +3645,16 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.5",
+      "version": "1.5.112",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.112.tgz",
+      "integrity": "sha1-jT2V1NVlODYyeJAoLI7aXG8mYm0=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emitter-listener": {
       "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha1-VrFA6PaZI3Wz18ssqxzHQy2WMug=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "shimmer": "^1.2.0"
@@ -3284,6 +3662,8 @@
     },
     "node_modules/emittery": {
       "version": "0.13.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha1-wEuMNFdJDghHrlH87Tr1LTOOPa0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3294,16 +3674,22 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
+      "version": "10.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha1-A1U6/qgLOXV0nPyzb3dsomjkE9Q=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/enabled": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha1-+d2S7C1vS7wNXR5k4h1hzUZl58I=",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3311,6 +3697,8 @@
     },
     "node_modules/environment": {
       "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha1-jobGaxgPNjx6sxF4fgJZZl9FqfE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3322,6 +3710,8 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3329,28 +3719,45 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo=",
       "license": "MIT"
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
+      "version": "3.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3359,10 +3766,14 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3372,24 +3783,26 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.16.0",
+      "version": "9.21.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.21.0.tgz",
+      "integrity": "sha1-scnBb1FT/yGXkfYnuUq48R+BFZE=",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.16.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.21.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.5",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^8.2.0",
@@ -3430,6 +3843,8 @@
     },
     "node_modules/eslint-formatter-junit": {
       "version": "8.40.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-formatter-junit/-/eslint-formatter-junit-8.40.0.tgz",
+      "integrity": "sha1-EY4rmnd7I3KLjk6DmFaFT/m5jG8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3437,7 +3852,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.9.0",
+      "version": "28.11.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+      "integrity": "sha1-JkHstEEZQbvds9fPio/xFj+7UQ4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3462,6 +3879,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-scope/-/eslint-scope-8.2.0.tgz",
+      "integrity": "sha1-N3qm8ctdx1ks/Qt/iS/QzzUs5EI=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -3475,32 +3894,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/debug": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha1-aHussq+IT83aim59ZcYG9GoUzUU=",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3509,12 +3905,10 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
-    },
     "node_modules/espree": {
       "version": "10.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha1-KSZ89bDLmHNbZeZLoH4O1J0e7Yo=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -3528,18 +3922,10 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -3552,6 +3938,8 @@
     },
     "node_modules/esquery": {
       "version": "1.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha1-kUGSNPgE2FKoLc7sPhbNwiz52uc=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -3562,6 +3950,8 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -3572,6 +3962,8 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -3579,6 +3971,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3586,6 +3980,8 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3593,6 +3989,8 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k=",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3600,11 +3998,15 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha1-U/X/0KSSrIAHIbtCxmuEHelkI8Q=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/events/-/events-3.3.0.tgz",
+      "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -3612,6 +4014,8 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3634,6 +4038,8 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -3641,6 +4047,8 @@
     },
     "node_modules/expect": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha1-V4h0WQ3LMhRRQITAgRXYruYeEbw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3656,6 +4064,8 @@
     },
     "node_modules/express": {
       "version": "4.21.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.21.2.tgz",
+      "integrity": "sha1-zyUOSDYhdOrWzqSlZqvvAWLB7DI=",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -3698,8 +4108,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "license": "MIT"
+    },
     "node_modules/extsprintf": {
-      "version": "1.3.0",
+      "version": "1.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha1-jRcsBkhn8jXAyEpZaAbSeb9LzAc=",
       "engines": [
         "node >=0.6.0"
       ],
@@ -3707,10 +4134,14 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
+      "version": "3.3.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3718,7 +4149,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -3726,6 +4157,8 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3737,14 +4170,20 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
+      "version": "1.19.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha1-1Q6rqAPIhGqIPBZJKCHrzSzaVfU=",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3752,6 +4191,8 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha1-6VJO5rXHfp5QAa8PhfOtu4YjJVw=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3760,10 +4201,14 @@
     },
     "node_modules/fecha": {
       "version": "4.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha1-TZzNvGHoYpsln9ymfmWJFEjVaf0=",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha1-d4e93PETG/+5JjbGlFe7wO3W2B8=",
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -3774,6 +4219,8 @@
     },
     "node_modules/filelist": {
       "version": "1.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha1-94l4oelEd1/55i50RCTyFeWDUrU=",
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
@@ -3781,6 +4228,8 @@
     },
     "node_modules/filelist/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3788,6 +4237,8 @@
     },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -3798,6 +4249,8 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3808,6 +4261,8 @@
     },
     "node_modules/finalhandler": {
       "version": "1.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha1-DFdfHR0yTd0do1rX7OPffRkIgBk=",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -3822,8 +4277,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -3838,6 +4310,8 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha1-Ds45/LFO4BL0sEEL0z3ZwfAREnw=",
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -3848,27 +4322,21 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
+      "version": "3.3.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha1-Z8j62VRUp8er6/dLt47nSkQCM1g=",
       "license": "ISC"
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha1-JsrYAXlnrqhzG8QpYdBKPVmIrMw=",
       "license": "MIT"
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3876,6 +4344,8 @@
     },
     "node_modules/fresh": {
       "version": "0.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3883,10 +4353,14 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3898,6 +4372,8 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3905,6 +4381,8 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3913,6 +4391,8 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3921,6 +4401,8 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha1-IbQHHuWO0E7g22UzcbVbQpmHU4k=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3931,14 +4413,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
+      "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3949,14 +4438,31 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3968,6 +4474,8 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -3986,6 +4494,8 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3995,7 +4505,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.13.0",
+      "version": "15.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha1-fEdhKZ1BwysHVxWkzh7eeJf/cqg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4006,43 +4518,9 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "license": "MIT"
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4051,8 +4529,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY=",
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4063,6 +4565,8 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4073,11 +4577,15 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha1-t3dKFIbvc892Z6ya4IWMASxXudM=",
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -4091,68 +4599,35 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
+      "version": "7.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
-    },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
+      "version": "7.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4161,6 +4636,8 @@
     },
     "node_modules/husky": {
       "version": "9.1.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha1-1Go4A10QG0anBFaoUP9CATRMCy0=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4175,6 +4652,8 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -4185,6 +4664,8 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
       "funding": [
         {
           "type": "github",
@@ -4203,6 +4684,8 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4210,10 +4693,14 @@
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "license": "ISC"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
+      "version": "3.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha1-nOy1ZQPAraHydB271lRuSxO1fM8=",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -4227,17 +4714,21 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
+      "version": "1.13.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
+      "integrity": "sha1-eJZR+ek92QKlowb0matR63KwOhI=",
       "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/import-local": {
       "version": "3.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha1-w9XHRXmMAqb4uJdyarpRABhu4mA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4256,6 +4747,8 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -4263,6 +4756,8 @@
     },
     "node_modules/inflection": {
       "version": "1.13.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha1-ZappbE4tpiJbFI16FUxEk2ZjOjI=",
       "engines": [
         "node >= 0.4.0"
       ],
@@ -4270,6 +4765,8 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -4278,10 +4775,14 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "license": "ISC"
     },
     "node_modules/ioredis": {
-      "version": "5.4.1",
+      "version": "5.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ioredis/-/ioredis-5.5.0.tgz",
+      "integrity": "sha1-/yMy4SXKKsjhVHLd0U7N/6ZISio=",
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
@@ -4302,27 +4803,10 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
-    "node_modules/ioredis/node_modules/debug": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ioredis/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -4330,11 +4814,15 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -4344,7 +4832,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
+      "version": "2.16.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4357,13 +4847,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "2.2.1",
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4371,21 +4863,30 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha1-+uMWfHKedGP4RhzlErCApJJoqog=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4394,6 +4895,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4402,8 +4905,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4411,6 +4934,8 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4418,6 +4943,8 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4427,21 +4954,30 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "2.2.0",
+      "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha1-4cZX45wQCQr8vt7GFyD2uSTDy9I=",
       "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0"
+        "is-inside-container": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha1-LRZsSwZE1Do58Ev2wu3R5YXzF1Y=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4450,6 +4986,8 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha1-+hVAHfbBWHS8shBfdzMl14xmZ2U=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4465,6 +5003,8 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha1-kIMFusmlvRdaxqdEier9D8JEWn0=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4478,6 +5018,8 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha1-iV86cJ/PujTG3lpCk5Ai8+Q1hVE=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4489,29 +5031,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
-      "version": "4.3.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/istanbul-reports": {
       "version": "3.1.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha1-2u0SueHcpRjhXAVuHlN+dBKA+gs=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4524,6 +5047,8 @@
     },
     "node_modules/jake": {
       "version": "10.9.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha1-auSH5qaa/sOl4WdiiZa1nzWuK38=",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.3",
@@ -4540,6 +5065,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha1-mUZ2/CQXfwiPHF43N/VpcgT/JhM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4565,6 +5092,8 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha1-HAbQfnfHjhWF0CBCTe3BDW4XrDo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4578,6 +5107,8 @@
     },
     "node_modules/jest-circus": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha1-toF6RfzINdixbVli0MAmRz7jZoo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4608,6 +5139,8 @@
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha1-VZLJQHmODK5nfuwWkmTy2DmjeZU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4640,6 +5173,8 @@
     },
     "node_modules/jest-config": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha1-vL2ogG28wBseMWpGu3QIWoSwJF8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4684,6 +5219,8 @@
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha1-AXk0pm67fs9vIF6EaZvhCv1wRYo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4698,6 +5235,8 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha1-j922rcPNyVXJPiqH9hz9NQ1dEZo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4709,6 +5248,8 @@
     },
     "node_modules/jest-each": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha1-FiqbPyMovdmRvqq/+7dHReVld9E=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4724,6 +5265,8 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha1-C5PhEd2o7BILyDAObR+5V24WQ3Y=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4740,6 +5283,8 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha1-NvSZ/c6hl8EEWhJzGcBIFyOQj9E=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4748,6 +5293,8 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha1-PCOWUkSC9aBQY3bmyFjDu8wXsQQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4772,6 +5319,8 @@
     },
     "node_modules/jest-junit": {
       "version": "16.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha1-2DjoxWHPn91+tU9jAgd37uQTZ4U=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4784,19 +5333,10 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/jest-junit/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha1-W37A2t/f7Ayjg9yaoBbTa16kxyg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4809,6 +5349,8 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha1-ro/sef8kn9WSzoDj7kdOg6bETxI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4823,6 +5365,8 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha1-i8OS4gTpXf51ZKu+cqQE4o5R9/M=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4842,6 +5386,8 @@
     },
     "node_modules/jest-mock": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha1-ToNs9g6Zxvz6vp+Z0Bfz/dUKY0c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4855,6 +5401,8 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha1-kwsVRhZNStWTfVVA5xHU041MrS4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4871,6 +5419,8 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha1-SlVtnHdq9o4cX0gZT00DJ9JOilI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4879,6 +5429,8 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha1-ZNaomS3Sb2NasMAeXu9Dmca8vDA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4898,6 +5450,8 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha1-GwTywJXzf8d2/0CAPckpIbHohCg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4910,6 +5464,8 @@
     },
     "node_modules/jest-runner": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha1-gJrwctQIpT3P0uhJpMl20xMvcY4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4941,6 +5497,8 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha1-7+yzFBz303Z6OgzI98mZBYfT2Bc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4973,6 +5531,8 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha1-wsV0w/UYZdobsykDZ3imm/iKa+U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5003,6 +5563,8 @@
     },
     "node_modules/jest-util": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha1-I8K2K/sivoK0TemAVYAv83EPwLw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5019,6 +5581,8 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha1-e/cFURxk2lkdRrFfzkFADVIUfZw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5035,6 +5599,8 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5046,6 +5612,8 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha1-eBDTDWGcOmIJMiPOa7NZyhsoovI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5064,6 +5632,8 @@
     },
     "node_modules/jest-worker": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha1-rK0HOsu663JivVOJ4bz0PhAFjUo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5078,6 +5648,8 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5092,15 +5664,21 @@
     },
     "node_modules/js-md4": {
       "version": "0.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5110,35 +5688,47 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
+      "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
       "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5150,6 +5740,8 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM=",
       "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
@@ -5168,12 +5760,10 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
-    },
     "node_modules/jwa": {
       "version": "1.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
@@ -5183,6 +5773,8 @@
     },
     "node_modules/jws": {
       "version": "3.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
       "license": "MIT",
       "dependencies": {
         "jwa": "^1.4.1",
@@ -5191,6 +5783,8 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -5198,6 +5792,8 @@
     },
     "node_modules/kleur": {
       "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5206,10 +5802,14 @@
     },
     "node_modules/kuler": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha1-4sVwo4ADiPtEQH6FFTHB1nCwYbM=",
       "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5218,6 +5818,8 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -5229,6 +5831,8 @@
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha1-obz9Ylf5WFv1rhTO7rt7VZAl5MQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5240,24 +5844,28 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "15.2.10",
+      "version": "15.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lint-staged/-/lint-staged-15.4.3.tgz",
+      "integrity": "sha1-5zWHzIV/WAyZ+Qer7+msjY1edME=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "~5.3.0",
-        "commander": "~12.1.0",
-        "debug": "~4.3.6",
-        "execa": "~8.0.1",
-        "lilconfig": "~3.1.2",
-        "listr2": "~8.2.4",
-        "micromatch": "~4.0.8",
-        "pidtree": "~0.6.0",
-        "string-argv": "~0.3.2",
-        "yaml": "~2.5.0"
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -5270,7 +5878,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.3.0",
+      "version": "5.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha1-G0i/CWPsFY3OKqz2nAk64t0gktg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5280,24 +5890,10 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/lint-staged/node_modules/debug": {
-      "version": "4.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/lint-staged/node_modules/execa": {
       "version": "8.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha1-UfallDtYD5Y8PKnGMheW24zDm4w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5320,6 +5916,8 @@
     },
     "node_modules/lint-staged/node_modules/get-stream": {
       "version": "8.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha1-3vnf1xdCzXdUp3Ye1DdJon0C7KI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5331,6 +5929,8 @@
     },
     "node_modules/lint-staged/node_modules/human-signals": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha1-QmZaKE+a4NreO6QevDfrS4UvOig=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5339,6 +5939,8 @@
     },
     "node_modules/lint-staged/node_modules/is-stream": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha1-5r/XqmvvafT0cs6btoHj5XtDGaw=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5350,6 +5952,8 @@
     },
     "node_modules/lint-staged/node_modules/mimic-fn": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha1-YKkFUNXLCyOcymXYk7GlOymHHsw=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5359,13 +5963,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lint-staged/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lint-staged/node_modules/npm-run-path": {
       "version": "5.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha1-4jNT0Ou5MX8XTpNBfkpNgtAknp8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5380,6 +5981,8 @@
     },
     "node_modules/lint-staged/node_modules/onetime": {
       "version": "6.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha1-fCTBjtH9LpvKS9JoBqM2E8d9NLQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5394,6 +5997,8 @@
     },
     "node_modules/lint-staged/node_modules/path-key": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha1-KVWI3DruZBVPh3rbnXgLgcVUvxg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5405,6 +6010,8 @@
     },
     "node_modules/lint-staged/node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5416,6 +6023,8 @@
     },
     "node_modules/lint-staged/node_modules/strip-final-newline": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha1-UolMMT+/8xiDUoCu1g/3Hr8SuP0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5427,6 +6036,8 @@
     },
     "node_modules/listr2": {
       "version": "8.2.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/listr2/-/listr2-8.2.5.tgz",
+      "integrity": "sha1-XJ25luGv6wXbBEgZbT1fZP7CWT0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5441,81 +6052,10 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/listr2/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/listr2/node_modules/string-width": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -5529,54 +6069,80 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "license": "MIT"
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "license": "MIT"
     },
     "node_modules/log-update": {
       "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha1-GgT/OBZvlGR64a9WL0vWoVsbfNQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5595,6 +6161,8 @@
     },
     "node_modules/log-update/node_modules/ansi-escapes": {
       "version": "7.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha1-APwZ9JG7sY4dSBuXhoIE+SEJv+c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5609,6 +6177,8 @@
     },
     "node_modules/log-update/node_modules/ansi-regex": {
       "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha1-lexAnGlhnWyxuLNPFLZg7yjr1lQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5620,6 +6190,8 @@
     },
     "node_modules/log-update/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha1-DmIyDPmcIa//OzASGSVGqsv7BcU=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5629,13 +6201,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/log-update/node_modules/is-fullwidth-code-point": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha1-lgnvztfC+X2ntgFF70gceHx7pwQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5650,6 +6219,8 @@
     },
     "node_modules/log-update/node_modules/slice-ansi": {
       "version": "7.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha1-zWtGVeKYqNG96wQlCkMwlLNHuak=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5663,24 +6234,10 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/string-width": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/log-update/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5693,24 +6250,10 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/logform": {
-      "version": "2.6.1",
+      "version": "2.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha1-z8qXUo7ykPLhJaCDloBQArLQYNE=",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -5724,13 +6267,10 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/logform/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
-    },
     "node_modules/login.dfe.api.auth": {
       "version": "2.3.3",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.api.auth.git#31c1db64742b683995d6fb2091725f4937739abb",
+      "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",
         "passport": "^0.6.0",
@@ -5740,6 +6280,7 @@
     "node_modules/login.dfe.config.schema.common": {
       "version": "2.1.6",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.config.schema.common.git#9070c5c87025152d2c6d4c80eefb3815873b8c01",
+      "license": "MIT",
       "dependencies": {
         "simpl-schema": "^3.4.1"
       }
@@ -5748,6 +6289,7 @@
       "version": "5.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-5.0.3.tgz",
       "integrity": "sha1-5ff2NtLhRFeXESo7sF/2jGqGw3M=",
+      "license": "ISC",
       "dependencies": {
         "eslint": "^8.12.0",
         "express": "^4.17.3",
@@ -5765,6 +6307,8 @@
     },
     "node_modules/login.dfe.dao/node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha1-OIomnw8lwbatwxe1osVXFIlMcK0=",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -5786,28 +6330,17 @@
     },
     "node_modules/login.dfe.dao/node_modules/@eslint/js": {
       "version": "8.57.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha1-3mM9s+wu9qPIni8ZA4Bj6KEi4sI=",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/login.dfe.dao/node_modules/debug": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/login.dfe.dao/node_modules/eslint": {
       "version": "8.57.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha1-ffEJZUq6fju+XI6uUzxeRh08bKk=",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -5861,6 +6394,8 @@
     },
     "node_modules/login.dfe.dao/node_modules/eslint-scope": {
       "version": "7.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha1-3rT5JWM5DzIAaJSvYqItuhxGQj8=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -5873,8 +6408,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/login.dfe.dao/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/login.dfe.dao/node_modules/espree": {
       "version": "9.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha1-oqF7jkNGkKVDLy+AGM5x0zGkjG8=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -5890,6 +6439,8 @@
     },
     "node_modules/login.dfe.dao/node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -5900,6 +6451,8 @@
     },
     "node_modules/login.dfe.dao/node_modules/flat-cache": {
       "version": "3.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha1-LAwtUEDJmxYydxqdEFclwBFTY+4=",
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -5912,6 +6465,8 @@
     },
     "node_modules/login.dfe.dao/node_modules/globals": {
       "version": "13.24.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha1-hDKhnXjODB6DOUnDats0VAC7EXE=",
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -5923,12 +6478,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/login.dfe.dao/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
+    "node_modules/login.dfe.dao/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/login.dfe.dao/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/login.dfe.dao/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -5941,6 +6521,7 @@
     "node_modules/login.dfe.express-error-handling": {
       "version": "3.0.1",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.express-error-handling.git#2b1de1f9e1cc8d14afff441ff97c344d9c6cbc86",
+      "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.6"
       }
@@ -5948,6 +6529,7 @@
     "node_modules/login.dfe.healthcheck": {
       "version": "3.0.2",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.healthcheck.git#c4f925a38c78992195a22fae93dfe3ad8fbe5a66",
+      "license": "MIT",
       "dependencies": {
         "express": "^4.17.3",
         "ioredis": "^5.3.2",
@@ -5959,6 +6541,7 @@
     "node_modules/login.dfe.jobs-client": {
       "version": "6.1.0",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jobs-client.git#0c271c49c7c91cdcea52acc148c27aaa152c0744",
+      "license": "MIT",
       "dependencies": {
         "bullmq": "^5.29.0"
       }
@@ -5966,6 +6549,7 @@
     "node_modules/login.dfe.jwt-strategies": {
       "version": "4.1.1",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#e73c81f47d8352b2609c2eeab691e5c68c8f6727",
+      "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^2.6.4"
       }
@@ -5973,6 +6557,7 @@
     "node_modules/login.dfe.winston-appinsights": {
       "version": "5.0.3",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.winston-appinsights.git#e38aff47f0db953fb93f82efb3287cd66ac08799",
+      "license": "MIT",
       "dependencies": {
         "applicationinsights": "^2.0.0",
         "winston-transport": "^4.4.0"
@@ -5982,11 +6567,15 @@
       }
     },
     "node_modules/long": {
-      "version": "5.2.3",
+      "version": "5.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/long/-/long-5.3.1.tgz",
+      "integrity": "sha1-nUIi0yE/OKXsgJZ0g04PCrIavpY=",
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5997,12 +6586,15 @@
       "version": "3.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/luxon/-/luxon-3.5.0.tgz",
       "integrity": "sha1-a29lxc0dYdH9Gdvwfuh6UL9LjiA=",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha1-w8IwencSd82WODBfkVwprnQbYU4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6017,14 +6609,27 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha1-Pl3SB5qC6BLpg8xmEMSiyw6qgBo=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6032,6 +6637,8 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha1-2AMZpl88eTU1Hlz9rI+TGFBNvtU=",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6039,11 +6646,15 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6052,6 +6663,8 @@
     },
     "node_modules/methods": {
       "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6059,6 +6672,8 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6071,6 +6686,8 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -6081,6 +6698,8 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6088,6 +6707,8 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -6098,6 +6719,8 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6106,6 +6729,8 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha1-rL4rM0n5m53qyn+3Dki4PpTmcHY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6117,6 +6742,8 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6127,6 +6754,8 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -6134,29 +6763,37 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.6",
+      "version": "1.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=",
       "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha1-+MkcB7enhuMMWZJt9TC06slpdK4=",
       "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.45",
+      "version": "0.5.47",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment-timezone/-/moment-timezone-0.5.47.tgz",
+      "integrity": "sha1-1NGiG3g3LZFNbWmuKFRUcypCl0k=",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -6167,6 +6804,8 @@
     },
     "node_modules/mongo-object": {
       "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mongo-object/-/mongo-object-3.0.1.tgz",
+      "integrity": "sha1-4NSjsjSBFRde0Zvr0/maErs4eYM=",
       "license": "MIT",
       "engines": {
         "node": ">=14.16",
@@ -6174,13 +6813,16 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/msgpackr": {
       "version": "1.11.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/msgpackr/-/msgpackr-1.11.2.tgz",
       "integrity": "sha1-RGO399aPLiSGXDlWZJc1Yq0kRz0=",
+      "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
       }
@@ -6190,6 +6832,7 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
       "integrity": "sha1-6dhwI945znFIcvnpUE48GZbWEBI=",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-gyp-build-optional-packages": "5.2.2"
@@ -6208,6 +6851,8 @@
     },
     "node_modules/mv": {
       "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6219,47 +6864,42 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/mv/node_modules/glob": {
-      "version": "6.0.4",
-      "license": "ISC",
+    "node_modules/mv/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mv/node_modules/rimraf": {
-      "version": "2.4.5",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^6.0.1"
+        "minimist": "^1.2.6"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/nan": {
-      "version": "2.20.0",
+      "version": "2.22.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha1-a1BP0Cn7jzjAmQ5SrVwmdy/az7s=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/native-duplexpair": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
+      "integrity": "sha1-eJkHjmS/PIo9cyYBs9QP8F21j6A=",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "license": "MIT"
     },
     "node_modules/ncp": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -6268,6 +6908,8 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha1-WOMjpy/twNb5zU0x/kn1FHlZDM0=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6276,10 +6918,13 @@
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg="
+      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg=",
+      "license": "MIT"
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha1-vo2iryQ7JBfV9kancGY6krfp3tM=",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -6289,6 +6934,7 @@
       "version": "5.2.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
       "integrity": "sha1-Ui9QwtUxNNfzp2zXJV3kq2yWo6Q=",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.1"
@@ -6301,11 +6947,15 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-jose": {
       "version": "2.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-jose/-/node-jose-2.2.0.tgz",
+      "integrity": "sha1-tk8yJa1r7DKFCaQggA3ll7or8+0=",
       "license": "Apache-2.0",
       "dependencies": {
         "base64url": "^3.0.1",
@@ -6321,6 +6971,8 @@
     },
     "node_modules/node-jose/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6331,12 +6983,12 @@
       }
     },
     "node_modules/node-mocks-http": {
-      "version": "1.15.1",
+      "version": "1.16.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-mocks-http/-/node-mocks-http-1.16.2.tgz",
+      "integrity": "sha1-Y+TJX5WPetxx1pucg5spy75gJz0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/express": "^4.17.21",
-        "@types/node": "*",
         "accepts": "^1.3.7",
         "content-disposition": "^0.5.3",
         "depd": "^1.1.0",
@@ -6350,10 +7002,24 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.21 || ^5.0.0",
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-mocks-http/node_modules/depd": {
       "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6361,12 +7027,16 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
+      "version": "2.0.19",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha1-nkRaUpUJUexNF32EOvNwtBHK8xQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nodemon": {
-      "version": "3.1.4",
+      "version": "3.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha1-31As3DsSDhw8DG5BUjSQGe+nOHs=",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -6391,34 +7061,19 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/nodemon/node_modules/has-flag": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
-    },
     "node_modules/nodemon/node_modules/supports-color": {
       "version": "5.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -6429,6 +7084,8 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6436,6 +7093,8 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6447,10 +7106,14 @@
     },
     "node_modules/oauth": {
       "version": "0.9.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE=",
       "license": "MIT"
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
+      "version": "1.13.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6461,6 +7124,8 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -6471,6 +7136,8 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6478,6 +7145,8 @@
     },
     "node_modules/one-time": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha1-4GvBdK7SFO1Y7e3lc7Qzu/gny0U=",
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
@@ -6485,6 +7154,8 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6498,15 +7169,18 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.2",
+      "version": "10.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/open/-/open-10.1.0.tgz",
+      "integrity": "sha1-p3lebl1Rmr5ChtmTe7JLURIlmOE=",
       "license": "MIT",
       "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6514,6 +7188,8 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -6529,6 +7205,8 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -6542,6 +7220,8 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -6555,6 +7235,8 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6563,10 +7245,14 @@
     },
     "node_modules/pako": {
       "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha1-JmzDf5jH2INUXREzXAD71AYsmoY=",
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -6577,6 +7263,8 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6594,6 +7282,8 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6601,6 +7291,8 @@
     },
     "node_modules/passport": {
       "version": "0.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha1-6GlXn6tGW1wLKR6EHmzJXABfrJ0=",
       "license": "MIT",
       "dependencies": {
         "passport-strategy": "1.x.x",
@@ -6617,6 +7309,8 @@
     },
     "node_modules/passport-azure-ad": {
       "version": "4.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/passport-azure-ad/-/passport-azure-ad-4.3.5.tgz",
+      "integrity": "sha1-EH1wlAkXBHjRpm7B77TAlN09Mhs=",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.3",
@@ -6635,14 +7329,43 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/passport-azure-ad/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/passport-azure-ad/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/passport-strategy": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ=",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6650,6 +7373,8 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6657,6 +7382,8 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6664,22 +7391,30 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha1-1eGhLkeKl21DLvPFjVNLmSMWS7c=",
       "license": "MIT"
     },
     "node_modules/pause": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "node_modules/pg": {
-      "version": "8.12.0",
+      "version": "8.13.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg/-/pg-8.13.3.tgz",
+      "integrity": "sha1-Gc0CHR+enSbYYLgM1FDxCahlJzg=",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.6.4",
-        "pg-pool": "^3.6.2",
-        "pg-protocol": "^1.6.1",
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.1",
+        "pg-protocol": "^1.7.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -6700,33 +7435,45 @@
     },
     "node_modules/pg-cloudflare": {
       "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha1-5tWDMBWxcOI66Bnoxdfq7bRyypg=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.4",
+      "version": "2.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha1-8dNInkJ8YuzgItupjVJi78sWizc=",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha1-lDvUY79bcbQXARX4D478mgwOt4w=",
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.2",
+      "version": "3.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-pool/-/pg-pool-3.7.1.tgz",
+      "integrity": "sha1-0ar2GGGNj4eKzxhehghJKLjNWzw=",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.1",
+      "version": "1.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-protocol/-/pg-protocol-1.7.1.tgz",
+      "integrity": "sha1-qtYab5J7Ueidz3IUCLdsDlNtQ9w=",
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha1-LQJQ1jZFT3z6O2rgOC/fqAYyVKM=",
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -6741,18 +7488,24 @@
     },
     "node_modules/pgpass": {
       "version": "1.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha1-m4c+SlZLsQ+np9vVUxJyjUIqIj0=",
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
+      "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6763,6 +7516,8 @@
     },
     "node_modules/pidtree": {
       "version": "0.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha1-kK17bULVhB5p4KJBnvOPiIOqBXw=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6774,6 +7529,8 @@
     },
     "node_modules/pirates": {
       "version": "4.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha1-MBiuMuz8/2wpuiJny/IRZqwfNrk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6782,6 +7539,8 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6793,6 +7552,8 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6805,6 +7566,8 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6816,6 +7579,8 @@
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6830,6 +7595,8 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6841,6 +7608,8 @@
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha1-SPj84FT7xpZxmZMpuINLdyZS2C4=",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6848,6 +7617,8 @@
     },
     "node_modules/postgres-bytea": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6855,6 +7626,8 @@
     },
     "node_modules/postgres-date": {
       "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha1-UbwIYAYAXlBhxZHO5yfyUxv2Qag=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6862,6 +7635,8 @@
     },
     "node_modules/postgres-interval": {
       "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha1-tGDILLFYdQd4iBmgaqD//bNURpU=",
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -6872,13 +7647,17 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
+      "version": "3.5.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha1-T8LODWV+egLmAlSfBTsjnLff4bU=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6893,6 +7672,8 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha1-ykLHWDEPNlv6caC9oKgHFgt3aBI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6906,6 +7687,8 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6917,6 +7700,8 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -6924,6 +7709,8 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha1-e1fnOzpIAprRDr1E90sBcipMsGk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6936,6 +7723,8 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -6947,10 +7736,14 @@
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha1-wkIiT0pnwh9oaDm720rCgrg3PTo=",
       "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6958,6 +7751,8 @@
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha1-0XPPIyWCMZdsy9sFJHyXh5V2BPI=",
       "dev": true,
       "funding": [
         {
@@ -6973,6 +7768,8 @@
     },
     "node_modules/qs": {
       "version": "6.13.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha1-bKO9WEOffiRWVXmJl3h7DYilGQY=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -6986,6 +7783,8 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
       "funding": [
         {
           "type": "github",
@@ -7004,6 +7803,8 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7011,6 +7812,8 @@
     },
     "node_modules/raw-body": {
       "version": "2.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha1-mf69g7kOCJdQh+jx+UGaFJNmtoo=",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -7024,11 +7827,15 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha1-6DVX3BLq5jqZ4AOkY4ix3LtE234=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/readable-stream": {
-      "version": "4.5.2",
+      "version": "4.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -7043,6 +7850,8 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -7053,6 +7862,8 @@
     },
     "node_modules/redis-errors": {
       "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7060,6 +7871,8 @@
     },
     "node_modules/redis-parser": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
       "license": "MIT",
       "dependencies": {
         "redis-errors": "^1.0.0"
@@ -7070,6 +7883,8 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7077,7 +7892,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.4.0",
+      "version": "7.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha1-3CWxSK/61C5XDPDkG6MNwA8XA+w=",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
@@ -7088,35 +7905,21 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/require-in-the-middle/node_modules/debug": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/require-in-the-middle/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
-    },
     "node_modules/resolve": {
-      "version": "1.22.8",
+      "version": "1.22.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha1-tmPoP/sJu/I4aURza6roAwKbizk=",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7124,6 +7927,8 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7135,6 +7940,8 @@
     },
     "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7143,13 +7950,17 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/resolve.exports": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha1-QZVebxtAE7dYb4c3SaY13qB+vj8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7158,6 +7969,8 @@
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha1-B2bZVpnvrLFBUJk/VbrwlT6h6+c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7173,6 +7986,8 @@
     },
     "node_modules/restore-cursor/node_modules/onetime": {
       "version": "7.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha1-nxbJLYye9RIOOs2d2ZV8zuzBq2A=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7187,6 +8002,8 @@
     },
     "node_modules/restore-cursor/node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -7197,11 +8014,15 @@
       }
     },
     "node_modules/retry-as-promised": {
-      "version": "7.0.4",
+      "version": "7.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/retry-as-promised/-/retry-as-promised-7.1.1.tgz",
+      "integrity": "sha1-NiYkbwTBlB/xDOvPo98Fd/2Kstc=",
       "license": "MIT"
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7210,24 +8031,57 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha1-d492xPtzHZNBTo+SX77PZMzn9so=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
+      "version": "2.4.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^6.0.1"
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha1-5aVTwr/9Yg4WnSdsHNjxtkd4++s=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
       "funding": [
         {
           "type": "github",
@@ -7249,6 +8103,8 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
       "funding": [
         {
           "type": "github",
@@ -7267,11 +8123,15 @@
     },
     "node_modules/safe-json-stringify": {
       "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha1-NW5EvJjx+TzkXfFLzXwBzahuCv0=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.4.3",
+      "version": "2.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha1-TKL444XygxxDKnGbEIo7969Cod0=",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7279,10 +8139,14 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha1-q9UJjYKxjGyB9gdP8mR/0+ciDJ8=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7293,6 +8157,8 @@
     },
     "node_modules/send": {
       "version": "0.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/send/-/send-0.19.0.tgz",
+      "integrity": "sha1-u8WjiMjqbASJZwSdvqwOSj8J1/g=",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -7313,19 +8179,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "license": "MIT"
+    },
     "node_modules/send/node_modules/encodeurl": {
       "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
-    },
     "node_modules/sequelize": {
-      "version": "6.37.3",
+      "version": "6.37.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.6.tgz",
+      "integrity": "sha1-zrLMSxk91BH2hGwetUqmHpxqz14=",
       "funding": [
         {
           "type": "opencollective",
@@ -7386,6 +8267,8 @@
     },
     "node_modules/sequelize-mock": {
       "version": "0.10.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize-mock/-/sequelize-mock-0.10.2.tgz",
+      "integrity": "sha1-GdOXHM2utbhkFwwkznkqinHxRL0=",
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.4.6",
@@ -7395,32 +8278,17 @@
     },
     "node_modules/sequelize-pool": {
       "version": "7.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha1-IQs5GvQAJ2L4IxiP1uz8dBMCB2g=",
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/sequelize/node_modules/debug": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/sequelize/node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
-    },
     "node_modules/serve-static": {
       "version": "1.16.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha1-tqU0PaR/a90mc4SL9FdUlB6AMpY=",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -7432,27 +8300,16 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha1-ZsmiSnP5/CjL5msJ/tPTPcrxtCQ=",
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7463,6 +8320,8 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7470,16 +8329,74 @@
     },
     "node_modules/shimmer": {
       "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha1-YQhZ994ye1h+/r9QH7QxF/mv8zc=",
       "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7490,11 +8407,15 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/simpl-schema": {
       "version": "3.4.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/simpl-schema/-/simpl-schema-3.4.6.tgz",
+      "integrity": "sha1-3+v1K1yiY1AxWRXjmU/+vVFbKeY=",
       "license": "MIT",
       "dependencies": {
         "clone": "^2.1.2",
@@ -7507,6 +8428,8 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
@@ -7514,10 +8437,14 @@
     },
     "node_modules/simple-swizzle/node_modules/is-arrayish": {
       "version": "0.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
       "license": "MIT"
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha1-1wuSvat9bZDf1zkxGVowtuPXzrs=",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -7528,11 +8455,15 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7541,6 +8472,8 @@
     },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha1-tzBjxXqpb5zYgWVLFSlNldKFxCo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7556,6 +8489,8 @@
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha1-DmIyDPmcIa//OzASGSVGqsv7BcU=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7565,19 +8500,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7586,6 +8512,8 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7595,6 +8523,8 @@
     },
     "node_modules/split2": {
       "version": "4.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha1-ycWSCQTRSLqwufZxRfJFqGqtv6Q=",
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -7602,14 +8532,20 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha1-SRS5A6L4toXRf994pw6RfocuREo=",
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-chain": {
       "version": "1.3.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
       "license": "MIT"
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -7617,6 +8553,8 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha1-qvB0gWnAL8M8gjKrzPkz9Uocw08=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7628,6 +8566,8 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7636,10 +8576,14 @@
     },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha1-iVP8BTWYaKd7W5c5pmXFl3u330U=",
       "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha1-VcsADM8dSHKL0jxoWgY5mM8aG2M=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7647,6 +8591,8 @@
     },
     "node_modules/stoppable": {
       "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs=",
       "license": "MIT",
       "engines": {
         "node": ">=4",
@@ -7655,6 +8601,8 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -7662,6 +8610,8 @@
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha1-K20O8ktlYnTZV9VOCku/YVPcArY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7670,6 +8620,8 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7681,20 +8633,56 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
+      "version": "7.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha1-lexAnGlhnWyxuLNPFLZg7yjr1lQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7705,6 +8693,8 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7713,6 +8703,8 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7721,6 +8713,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7731,6 +8725,8 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7741,6 +8737,8 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7750,7 +8748,9 @@
       }
     },
     "node_modules/tedious": {
-      "version": "18.3.0",
+      "version": "18.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-18.6.1.tgz",
+      "integrity": "sha1-HEo/BsiRvmegMhF+LiUZMobURJY=",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.7.2",
@@ -7770,6 +8770,8 @@
     },
     "node_modules/tedious/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7780,6 +8782,8 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7793,27 +8797,27 @@
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU=",
       "license": "MIT"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha1-hoPguQK7nCDE9ybjwLafNlGMB8w=",
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7824,6 +8828,8 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha1-O+NDIaiKgg7RvYDfqjPkefu43TU=",
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -7831,10 +8837,14 @@
     },
     "node_modules/toposort-class": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=",
       "license": "MIT"
     },
     "node_modules/touch": {
       "version": "3.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha1-CXoj17FhR2Q15cE0SpXA91tKVpQ=",
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
@@ -7842,28 +8852,36 @@
     },
     "node_modules/triple-beam": {
       "version": "1.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha1-b95wJx3G5dc8oMOyTi2Sr7dEGYQ=",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
+      "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha1-ZgcpOFtiW5OaqlgFT0XAWPM/EM0=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
+      "version": "2.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -7874,6 +8892,8 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7881,7 +8901,10 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
+      "version": "0.21.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -7892,6 +8915,8 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -7902,7 +8927,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
+      "version": "5.8.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha1-gXCzcC90t52y5aliB8FeZYB5meQ=",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -7916,21 +8943,29 @@
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha1-OHM7kye9zSJtuIn7cjpu/RYubiw=",
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.13.0",
+      "version": "6.20.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha1-gXG/IsH1iNFVTVW/IEvGJK84hDM=",
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
+      "version": "1.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha1-NIN33SRSFvnnBg/1CxWht0C3VCA=",
       "dev": true,
       "funding": [
         {
@@ -7948,8 +8983,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -7960,6 +8995,8 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -7967,10 +9004,14 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -7978,6 +9019,8 @@
     },
     "node_modules/uuid": {
       "version": "8.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -7985,6 +9028,8 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha1-uVcqv6Yr1VbBbXX968GkEdX/MXU=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7997,10 +9042,14 @@
       }
     },
     "node_modules/valid-url": {
-      "version": "1.0.9"
+      "version": "1.0.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "node_modules/validator": {
       "version": "13.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha1-fXjna6hVBNo/7k/Rkis4WRTUs18=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -8008,6 +9057,8 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8015,6 +9066,8 @@
     },
     "node_modules/verror": {
       "version": "1.10.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha1-S/Ce7M9FY7EJ7Us9RYOAyXKwzes=",
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
@@ -8027,6 +9080,8 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha1-vUmNtHev5XPcBBhfAR06uKjXZT8=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8035,6 +9090,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8047,30 +9104,34 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.13.1",
+      "version": "3.17.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha1-dLhmXOm06nsp0JIs/M+FKgihFCM=",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.7.1",
+      "version": "4.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha1-O7o0XeECl2VOpvM1GUJFYAA7O/k=",
       "license": "MIT",
       "dependencies": {
-        "logform": "^2.6.1",
+        "logform": "^2.7.0",
         "readable-stream": "^3.6.2",
         "triple-beam": "^1.3.0"
       },
@@ -8080,6 +9141,8 @@
     },
     "node_modules/winston-transport/node_modules/readable-stream": {
       "version": "3.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -8092,6 +9155,8 @@
     },
     "node_modules/winston/node_modules/readable-stream": {
       "version": "3.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -8104,6 +9169,8 @@
     },
     "node_modules/wkx": {
       "version": "0.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha1-xsNwGaz0DlF8xrlGV6JaPUqjPow=",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8111,33 +9178,83 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
+      "version": "9.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha1-Gj3Itw2F7rg5jd+x5KAs0Ybliz4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha1-lexAnGlhnWyxuLNPFLZg7yjr1lQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha1-DmIyDPmcIa//OzASGSVGqsv7BcU=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha1-qd8Brlt3hYoCf9LoB2juQzVV/P0=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8150,11 +9267,15 @@
     },
     "node_modules/xml": {
       "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
@@ -8162,6 +9283,8 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -8170,11 +9293,15 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
+      "version": "2.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha1-rvm7YXpkyTepp0iAN4atjT/+Hpg=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8186,6 +9313,8 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8203,14 +9332,50 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,6 @@
         "lint-staged": "^15.2.10",
         "node-mocks-http": "^1.11.0",
         "prettier": "^3.4.2"
-      },
-      "engines": {
-        "node": "18.17.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -37,18 +37,18 @@
     "winston": "^3.17.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.16.0",
-    "eslint": "^9.16.0",
+    "@eslint/js": "^9.21.0",
+    "eslint": "^9.21.0",
     "eslint-formatter-junit": "^8.40.0",
-    "eslint-plugin-jest": "^28.9.0",
-    "globals": "^15.13.0",
+    "eslint-plugin-jest": "^28.11.0",
+    "globals": "^15.15.0",
     "husky": "^9.1.7",
-    "jest": "^29.6.3",
-    "jest-cli": "^29.6.3",
+    "jest": "^29.7.0",
+    "jest-cli": "^29.7.0",
     "jest-junit": "^16.0.0",
-    "lint-staged": "^15.2.10",
-    "node-mocks-http": "^1.11.0",
-    "prettier": "^3.4.2"
+    "lint-staged": "^15.4.3",
+    "node-mocks-http": "^1.16.2",
+    "prettier": "^3.5.3"
   },
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "login.dfe.saml-assertions",
   "version": "6.0.0",
-  "engines": {
-    "node": "18.17.0"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/DFE-Digital/login.dfe.saml-assertions.git"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
     "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.6",
     "login.dfe.dao": "^5.0.3",
-    "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
+    "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.2",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
     "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "applicationinsights": "^2.0.0",
-    "express": "^4.18.1",
+    "applicationinsights": "^2.9.6",
+    "express": "^4.21.2",
     "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
     "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.6",
     "login.dfe.dao": "^5.0.3",
@@ -32,9 +32,9 @@
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
     "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
-    "nodemon": "^3.1.4",
-    "simpl-schema": "^3.4.1",
-    "winston": "^3.8.2"
+    "nodemon": "^3.1.9",
+    "simpl-schema": "^3.4.6",
+    "winston": "^3.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",


### PR DESCRIPTION
### Summary
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-7560

### Changes
- Delete engines section from package.json.
- Update pipeline related files for Node 22, specifically 22.11.0
- Updated some of the 3rd party packages where deemed safe
- Update internal DfE packages to latest version